### PR TITLE
Update libraries.dart path to keep up with SDK shuffle.

### DIFF
--- a/tools/plugins/com.google.dart.engine/src/com/google/dart/engine/sdk/DirectoryBasedDartSdk.java
+++ b/tools/plugins/com.google.dart.engine/src/com/google/dart/engine/sdk/DirectoryBasedDartSdk.java
@@ -583,10 +583,14 @@ public class DirectoryBasedDartSdk implements DartSdk {
    * @return the initialized library map
    */
   protected LibraryMap initialLibraryMap(boolean useDart2jsPaths) {
-    //dart-sdk/lib/_internal/sdk_library_metadata/lib
+
     File librariesFile = new File(new File(new File(
         new File(getLibraryDirectory(), INTERNAL_DIR),
         SDK_LIB_METADATA_DIR), SDK_LIB_METADATA_LIB_DIR), LIBRARIES_FILE);
+    if (!librariesFile.exists()) {
+      // Fall back to pre SDK reorg location.
+      librariesFile = getLegacyLibrariesFile();
+    }
     try {
       String contents = FileUtilities.getContents(librariesFile);
       return new SdkLibrariesReader(useDart2jsPaths).readFromFile(librariesFile, contents);
@@ -596,6 +600,13 @@ public class DirectoryBasedDartSdk implements DartSdk {
           exception);
       return new LibraryMap();
     }
+  }
+
+  /**
+   * Get the libraries file location, pre SDK-shuffle.
+   */
+  File getLegacyLibrariesFile() {
+    return new File(new File(getLibraryDirectory(), INTERNAL_DIR), LIBRARIES_FILE);
   }
 
   /**

--- a/tools/plugins/com.google.dart.engine/src/com/google/dart/engine/sdk/DirectoryBasedDartSdk.java
+++ b/tools/plugins/com.google.dart.engine/src/com/google/dart/engine/sdk/DirectoryBasedDartSdk.java
@@ -196,6 +196,17 @@ public class DirectoryBasedDartSdk implements DartSdk {
   private static final String PUB_EXECUTABLE_NAME = "pub"; //$NON-NLS-1$
 
   /**
+   * The name of the directory within the SDK directory that contains libraries metadata.
+   */
+  private static final String SDK_LIB_METADATA_DIR = "sdk_library_metadata"; //$NON-NLS-1$
+
+  /**
+   * The name of the directory within the SDK library metadata directory that contains
+   * 'libraries.dart'.
+   */
+  private static final String SDK_LIB_METADATA_LIB_DIR = "lib"; //$NON-NLS-1$
+
+  /**
    * The name of the file within the SDK directory that contains the version number of the SDK.
    */
   private static final String VERSION_FILE_NAME = "version"; //$NON-NLS-1$
@@ -572,7 +583,10 @@ public class DirectoryBasedDartSdk implements DartSdk {
    * @return the initialized library map
    */
   protected LibraryMap initialLibraryMap(boolean useDart2jsPaths) {
-    File librariesFile = new File(new File(getLibraryDirectory(), INTERNAL_DIR), LIBRARIES_FILE);
+    //dart-sdk/lib/_internal/sdk_library_metadata/lib
+    File librariesFile = new File(new File(new File(
+        new File(getLibraryDirectory(), INTERNAL_DIR),
+        SDK_LIB_METADATA_DIR), SDK_LIB_METADATA_LIB_DIR), LIBRARIES_FILE);
     try {
       String contents = FileUtilities.getContents(librariesFile);
       return new SdkLibrariesReader(useDart2jsPaths).readFromFile(librariesFile, contents);


### PR DESCRIPTION
TL;DR: this is required for initializing the library map.

@scheglov @bwilkerson 

cc: @keertip 