### PR TITLE
Only --break-at-isolate-spawn when debugging.

### DIFF
--- a/tools/plugins/com.google.dart.tools.debug.core/src/com/google/dart/tools/debug/core/configs/DartServerLaunchConfigurationDelegate.java
+++ b/tools/plugins/com.google.dart.tools.debug.core/src/com/google/dart/tools/debug/core/configs/DartServerLaunchConfigurationDelegate.java
@@ -195,7 +195,9 @@ public class DartServerLaunchConfigurationDelegate extends DartLaunchConfigurati
     }
 
     // This lets us debug isolates.
-    commandsList.add("--break-at-isolate-spawn");
+    if (enableDebugging) {
+      commandsList.add("--break-at-isolate-spawn");
+    }
 
     String coverageTempDir = null;
     if (DartCoreDebug.ENABLE_COVERAGE) {


### PR DESCRIPTION
This fixed a snag we hit a while back.

@devoncarew @keertip PTAL?